### PR TITLE
Update token server sandbox docs to point to project settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This project includes a sample iOS app that you can build yourself.
 ### Setup
 
 1. Open `swift-frontend/VisionDemo/VisionDemo.xcodeproj` in Xcode.
-2. Create a file `swift-frontend/VisionDemo/Resources/Secrets.xcconfig` with `LK_SANDBOX_TOKEN_SERVER_ID=` and your `sandboxId` from your project's **Options** at the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page.
+2. Create a file `swift-frontend/VisionDemo/Resources/Secrets.xcconfig` with `LK_SANDBOX_TOKEN_SERVER_ID=` and your token server's unique ID.
 3. Edit the bundle identifier for the `VisionDemo` target to a suitable values for your own use.
 4. Edit the bundle identifier for the `BroadcastExtension` to `<your-bundle-identifier>.broadcast`.
 4. Create a new App Group called `group.<your-bundle-identifier>` and select it in the "Signing & Capabilities" section of the `VisionDemo` target.

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ This project includes a sample iOS app that you can build yourself.
 - Xcode 16
 - Device with iOS 17+ (simulator is not supported)
 - [LiveKit Cloud](https://cloud.livekit.io) project
-- A [Sandbox](https://docs.livekit.io/cloud/sandbox/) [token server](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server)
+- A [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) (enable from your project's **Options** at the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page)
 
 ### Setup
 
 1. Open `swift-frontend/VisionDemo/VisionDemo.xcodeproj` in Xcode.
-2. Create a file `swift-frontend/VisionDemo/Resources/Secrets.xcconfig` with `LK_SANDBOX_TOKEN_SERVER_ID=` and your token server's unique ID.
+2. Create a file `swift-frontend/VisionDemo/Resources/Secrets.xcconfig` with `LK_SANDBOX_TOKEN_SERVER_ID=` and your `sandboxId` from your project's **Options** at the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page.
 3. Edit the bundle identifier for the `VisionDemo` target to a suitable values for your own use.
 4. Edit the bundle identifier for the `BroadcastExtension` to `<your-bundle-identifier>.broadcast`.
 4. Create a new App Group called `group.<your-bundle-identifier>` and select it in the "Signing & Capabilities" section of the `VisionDemo` target.
@@ -86,4 +86,4 @@ This project includes a sample iOS app that you can build yourself.
 
 # Self-Hosted Options
 
-This project is built with the LiveKit Cloud [Sandbox token server](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server) to make token generation easy. If you want to self-host or run a local LiveKit instance, you'll need to modify `swift-frontend/VisionDemo/Services/TokenService.swift` file to fetch your token from your own server and remove the `noise-cancellation` plugin from the agent ([enhanced noise cancellation](https://docs.livekit.io/cloud/noise-cancellation/) is a LiveKit Cloud feature).
+This project is built with the LiveKit Cloud [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) (enable from your project's **Options** at the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page) to make token generation easy. If you want to self-host or run a local LiveKit instance, you'll need to modify `swift-frontend/VisionDemo/Services/TokenService.swift` file to fetch your token from your own server and remove the `noise-cancellation` plugin from the agent ([enhanced noise cancellation](https://docs.livekit.io/cloud/noise-cancellation/) is a LiveKit Cloud feature).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This project includes a sample iOS app that you can build yourself.
 - Xcode 16
 - Device with iOS 17+ (simulator is not supported)
 - [LiveKit Cloud](https://cloud.livekit.io) project
-- A [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) (enable from your project's **Options** at the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page)
+- A [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) (enable from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page)
 
 ### Setup
 
@@ -86,4 +86,4 @@ This project includes a sample iOS app that you can build yourself.
 
 # Self-Hosted Options
 
-This project is built with the LiveKit Cloud [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) (enable from your project's **Options** at the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page) to make token generation easy. If you want to self-host or run a local LiveKit instance, you'll need to modify `swift-frontend/VisionDemo/Services/TokenService.swift` file to fetch your token from your own server and remove the `noise-cancellation` plugin from the agent ([enhanced noise cancellation](https://docs.livekit.io/cloud/noise-cancellation/) is a LiveKit Cloud feature).
+This project is built with the LiveKit Cloud [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) (enable from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page) to make token generation easy. If you want to self-host or run a local LiveKit instance, you'll need to modify `swift-frontend/VisionDemo/Services/TokenService.swift` file to fetch your token from your own server and remove the `noise-cancellation` plugin from the agent ([enhanced noise cancellation](https://docs.livekit.io/cloud/noise-cancellation/) is a LiveKit Cloud feature).

--- a/swift-frontend/VisionDemo/Services/TokenService.swift
+++ b/swift-frontend/VisionDemo/Services/TokenService.swift
@@ -1,7 +1,7 @@
 /// An example service for fetching LiveKit authentication tokens
 ///
 /// To use the LiveKit Cloud sandbox (development only)
-/// - Enable your sandbox here https://cloud.livekit.io/projects/p_/sandbox/templates/token-server
+/// - Enable the token server from your project's Options at the Settings page: https://cloud.livekit.io/projects/p_/settings/project
 /// - Create .env.xcconfig with your LIVEKIT_SANDBOX_ID
 ///
 /// To use a hardcoded token (development only)

--- a/swift-frontend/VisionDemo/Services/TokenService.swift
+++ b/swift-frontend/VisionDemo/Services/TokenService.swift
@@ -1,7 +1,7 @@
 /// An example service for fetching LiveKit authentication tokens
 ///
 /// To use the LiveKit Cloud sandbox (development only)
-/// - Enable the token server from your project's Options at the Settings page: https://cloud.livekit.io/projects/p_/settings/project
+/// - Enable the token server from your project's Options on the Settings page: https://cloud.livekit.io/projects/p_/settings/project
 /// - Create .env.xcconfig with your LIVEKIT_SANDBOX_ID
 ///
 /// To use a hardcoded token (development only)


### PR DESCRIPTION
- Updated docs to reflect that the sandbox token server is now auto-generated at the project level